### PR TITLE
Tor proxy

### DIFF
--- a/clients/standalone-rust/Settings.toml
+++ b/clients/standalone-rust/Settings.toml
@@ -1,4 +1,5 @@
-statechain_entity = "http://127.0.0.1:8000"
+statechain_entity = "caqa7fv4wmmhj7owhmkdq23nfejxoibsi74qos2ggldbtg75u45g4uid.onion"
+tor_proxy = ""socks5://127.0.0.1:9150"
 electrum_server = "tcp://127.0.0.1:50001"
 network = "signet"
 fee_rate_tolerance = 5

--- a/clients/standalone-rust/src/client_config/mod.rs
+++ b/clients/standalone-rust/src/client_config/mod.rs
@@ -8,6 +8,8 @@ use sqlx::{Sqlite, migrate::MigrateDatabase, SqlitePool};
 pub struct ClientConfig {
     /// Active lockbox server addresses
     pub statechain_entity: String,
+    /// Tor SOCKS5 proxy address
+    pub tor_proxy: String,
     /// Electrum client
     pub electrum_client: electrum_client::Client,
     /// Electrum server url
@@ -28,6 +30,7 @@ impl ClientConfig {
             .unwrap();
 
         let statechain_entity = settings.get_string("statechain_entity").unwrap();
+        let tor_proxy = settings.get_string("tor_proxy").unwrap();
         let electrum_server = settings.get_string("electrum_server").unwrap();
         let network = settings.get_string("network").unwrap();
         let fee_rate_tolerance = settings.get_int("fee_rate_tolerance").unwrap() as u32;
@@ -66,6 +69,7 @@ impl ClientConfig {
 
         ClientConfig {
             statechain_entity,
+            tor_proxy,
             electrum_client,
             electrum_server_url: electrum_server,
             network,

--- a/clients/standalone-rust/src/deposit.rs
+++ b/clients/standalone-rust/src/deposit.rs
@@ -131,7 +131,14 @@ pub async fn init(client_config: &ClientConfig, address_data: &key_derivation::A
     let endpoint = client_config.statechain_entity.clone();
     let path = "deposit/init/pod";
 
-    let client: reqwest::Client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
+
     let request = client.post(&format!("{}/{}", endpoint, path));
 
     let value = match request.json(&deposit_request_payload).send().await {

--- a/clients/standalone-rust/src/transaction.rs
+++ b/clients/standalone-rust/src/transaction.rs
@@ -46,7 +46,7 @@ pub async fn new_backup_transaction(
     const BACKUP_TX_SIZE: u64 = 112; // virtual size one input P2TR and one output P2TR
     // 163 is the real size one input P2TR and one output P2TR
 
-    let info_config_data = crate::utils::info_config(&client_config.statechain_entity, &client_config.electrum_client).await.unwrap();
+    let info_config_data = crate::utils::info_config(&client_config.statechain_entity, &client_config.electrum_client, &client_config.tor_proxy).await.unwrap();
 
     let initlock = info_config_data.initlock;
     let interval = info_config_data.interval;

--- a/clients/standalone-rust/src/transaction.rs
+++ b/clients/standalone-rust/src/transaction.rs
@@ -235,7 +235,13 @@ async fn musig_sign_psbt_taproot(
     let endpoint = client_config.statechain_entity.clone();
     let path = "sign/first";
 
-    let client: reqwest::Client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.post(&format!("{}/{}", endpoint, path));
 
     let sign_first_request_payload = SignFirstRequestPayload {
@@ -324,7 +330,13 @@ async fn musig_sign_psbt_taproot(
 
     let path = "sign/second";
 
-    let client: reqwest::Client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.post(&format!("{}/{}", endpoint, path));
 
     let value = match request.json(&payload).send().await {

--- a/clients/standalone-rust/src/transfer_receiver.rs
+++ b/clients/standalone-rust/src/transfer_receiver.rs
@@ -12,7 +12,13 @@ async fn get_msg_addr(auth_pubkey: &secp256k1_zkp::PublicKey, statechain_entity_
     let endpoint = statechain_entity_url;
     let path = format!("transfer/get_msg_addr/{}", auth_pubkey.to_string());
 
-    let client: reqwest::Client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.get(&format!("{}/{}", endpoint, path));
 
     let value = match request.send().await {
@@ -247,7 +253,13 @@ async fn get_statechain_info(statechain_id: &str, statechain_entity_url: &str) -
     println!("statechain_id: {}", statechain_id.to_string());
     println!("path: {}", path);
 
-    let client: reqwest::Client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.get(&format!("{}/{}", endpoint, path));
 
     let value = match request.send().await {
@@ -400,7 +412,13 @@ async fn process_encrypted_message(
         let endpoint = client_config.statechain_entity.clone();
         let path = "transfer/receiver";
 
-        let client = reqwest::Client::new();
+        let tor_proxy = client_config.tor_proxy.clone();
+
+        let mut client: reqwest::Client = reqwest::Client::new();
+        if tor_proxy != "".to_string() {
+            let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+            client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+        }
         let request = client.post(&format!("{}/{}", endpoint, path));
 
         let value = match request.json(&transfer_receiver_request_payload).send().await {

--- a/clients/standalone-rust/src/transfer_sender.rs
+++ b/clients/standalone-rust/src/transfer_sender.rs
@@ -28,7 +28,13 @@ async fn get_new_x1(client_config: &ClientConfig,  statechain_id: &str, signed_s
     let endpoint = client_config.statechain_entity.clone();
     let path = "transfer/sender";
 
-    let client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.post(&format!("{}/{}", endpoint, path));
 
     let transfer_sender_request_payload = TransferSenderRequestPayload {
@@ -163,7 +169,13 @@ pub async fn init(client_config: &ClientConfig, recipient_address: &str, statech
     let endpoint = client_config.statechain_entity.clone();
     let path = "transfer/update_msg";
 
-    let client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.post(&format!("{}/{}", endpoint, path));
 
     match request.json(&transfer_update_msg_request_payload).send().await {

--- a/clients/standalone-rust/src/utils.rs
+++ b/clients/standalone-rust/src/utils.rs
@@ -1,4 +1,5 @@
 use crate::{error::CError, electrum};
+use crate::client_config::ClientConfig;
 
 pub struct InfoConfig {
     pub initlock: u32,
@@ -6,11 +7,9 @@ pub struct InfoConfig {
     pub fee_rate_sats_per_byte: u64,
 }
 
-pub async fn info_config(statechain_entity_url: &str, electrum_client: &electrum_client::Client) -> Result<InfoConfig, CError>{
+pub async fn info_config(statechain_entity_url: &str, electrum_client: &electrum_client::Client, tor_proxy: &str) -> Result<InfoConfig, CError>{
 
     let path = "info/config";
-
-    let tor_proxy = client_config.tor_proxy.clone();
 
     let mut client: reqwest::Client = reqwest::Client::new();
     if tor_proxy != "".to_string() {

--- a/clients/standalone-rust/src/utils.rs
+++ b/clients/standalone-rust/src/utils.rs
@@ -10,7 +10,13 @@ pub async fn info_config(statechain_entity_url: &str, electrum_client: &electrum
 
     let path = "info/config";
 
-    let client: reqwest::Client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.get(&format!("{}/{}", statechain_entity_url, path));
 
     let value = match request.send().await {

--- a/clients/standalone-rust/src/withdraw.rs
+++ b/clients/standalone-rust/src/withdraw.rs
@@ -52,7 +52,13 @@ pub async fn execute(client_config: &ClientConfig, statechain_id: &str, to_addre
     let endpoint = client_config.statechain_entity.clone();
     let path = "delete_statechain";
 
-    let client: reqwest::Client = reqwest::Client::new();
+    let tor_proxy = client_config.tor_proxy.clone();
+
+    let mut client: reqwest::Client = reqwest::Client::new();
+    if tor_proxy != "".to_string() {
+        let tor_proxy = reqwest::Proxy::all(tor_proxy).unwrap();
+        client = reqwest::Client::builder().proxy(tor_proxy).build().unwrap();
+    }
     let request = client.delete(&format!("{}/{}", endpoint, path));
 
     let _ = match request.json(&delete_statechain_payload).send().await {


### PR DESCRIPTION
Connect to the mercury server via tor SOCKS5 proxy. 

If `tor_proxy` is empty, normal reqwest client is used. 